### PR TITLE
Fix compilation warnings

### DIFF
--- a/libtuxtxt/tuxtxt_common.h
+++ b/libtuxtxt/tuxtxt_common.h
@@ -4405,7 +4405,7 @@ void tuxtxt_RenderCharIntern(tstRenderInfo* renderinfo,int Char, tstPageAttr *At
 		for (Row = he; Row; Row--) /* row counts up, but down may be a little faster :) */
 		{
 			int pixtodo = (renderinfo->usettf ? renderinfo->sbit->width : curfontwidth);
-			char *pstart = p;
+			unsigned char *pstart = p;
 
 			for (Bit = xfactor * (renderinfo->sbit->left + renderinfo->TTFShiftX); Bit > 0; Bit--) /* fill left margin */
 			{
@@ -5822,7 +5822,7 @@ void tuxtxt_EndRendering(tstRenderInfo* renderinfo)
 	if ((renderinfo->fb=open(FB_DEV, O_RDWR)) == -1)
 	{
 		printf("TuxTxt <open %s>: %m", FB_DEV);
-		return 0;
+		return;
 	}
 
 	if (renderinfo->CleanAlgo == 4) /* 4 = restore var_screeninfo then framebuffer */
@@ -5831,7 +5831,7 @@ void tuxtxt_EndRendering(tstRenderInfo* renderinfo)
 		if (ioctl(renderinfo->fb, FBIOPUT_VSCREENINFO, &renderinfo->saved_var_screeninfo) == -1)
 		{
 			perror("TuxTxt <FBIOGET_VSCREENINFO>");
-			return 0;
+			return;
 		}
 	}
 	
@@ -5843,7 +5843,7 @@ void tuxtxt_EndRendering(tstRenderInfo* renderinfo)
 		if (!my_lfb)
 		{
 			perror("TuxTxt <mmap>");
-			return 0;
+			return;
 		}
 		memcpy(my_lfb, renderinfo->saved_fb, renderinfo->saved_fix_screeninfo.smem_len);
 		msync(my_lfb, renderinfo->saved_fix_screeninfo.smem_len, MS_SYNC);
@@ -5857,7 +5857,7 @@ void tuxtxt_EndRendering(tstRenderInfo* renderinfo)
 		if (ioctl(renderinfo->fb, FBIOPUT_VSCREENINFO, &renderinfo->saved_var_screeninfo) == -1)
 		{
 			perror("TuxTxt <FBIOGET_VSCREENINFO>");
-			return 0;
+			return;
 		}
 	}
 	


### PR DESCRIPTION
First error was incompatible type, so make them same. Also avoid return value in `void` function is pointless.